### PR TITLE
Fix warning on set-output

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -134,7 +134,7 @@ runs:
   steps:
       - name: Get R version
         id: r-version
-        run: echo "::set-output name=R_VERSION::$(R --version | head -1 | awk '{print $3}')"
+        run: echo "{name}={R_VERSION::$(R --version | head -1 | awk '{print $3}')}" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Set R Library home on Linux
@@ -215,7 +215,8 @@ runs:
         id: bioccheck-version
         run: |
           VERSION=$(R -s -e 'sink(stdout(), type = "message"); message(packageVersion("BiocCheck"))')
-          echo "::set-output name=VERSION::${VERSION}"
+          echo "{name}={VERSION::${VERSION}}" >> $GITHUB_OUTPUT
+          
         shell: bash
 
       - name: Run BiocCheck


### PR DESCRIPTION
`set_output` is deprecated. See this [changelog](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) for reference

## Changes description

Updating action.yaml to be up to date with the latest changes
